### PR TITLE
fix: Run browserify and Chromium locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 dist/aria.js: index.js lib/*.js
 	mkdir -p dist
-	browserify $< -o $@ -s aria
+	npx browserify $< -o $@ -s aria
 
 test/%.js: test/src/%.js
-	browserify -t brfs $< -o $@
+	npx browserify -t brfs $< -o $@
 
 test: test/test-name.js
-	PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium ./node_modules/.bin/mocha-headless-chrome -a no-sandbox -f test/index.html
+	npx mocha-headless-chrome -a no-sandbox -f test/index.html
 
 install:
-	PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install
+	npm install
 
 clean:
 	rm -f dist/aria.js


### PR DESCRIPTION
This uses the instances of packages installed by npm, rather than relying on global ones.

I noticed the `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1` in the `install` target, so it may well be that you have a different set-up and prefer the global packages, but I made the changes so that I could run the tests on my machine, so thought I'd offer them.