### PR TITLE
Be more flexible about installation location of chromium for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test/%.js: test/src/%.js
 	npx browserify -t brfs $< -o $@
 
 test: test/test-name.js
-	PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium npx mocha-headless-chrome -a no-sandbox -f test/index.html
+	PUPPETEER_EXECUTABLE_PATH=$(which chromium) npx mocha-headless-chrome -a no-sandbox -f test/index.html
 
 install:
 	PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test/%.js: test/src/%.js
 	npx browserify -t brfs $< -o $@
 
 test: test/test-name.js
-	PUPPETEER_EXECUTABLE_PATH=$(which chromium) npx mocha-headless-chrome -a no-sandbox -f test/index.html
+	PUPPETEER_EXECUTABLE_PATH=$$(which chromium) npx mocha-headless-chrome -a no-sandbox -f test/index.html
 
 install:
 	PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ test: test/test-name.js
 install:
 	PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install
 
+install-chromium:
+	npm install -f --no-save puppeteer
+
 clean:
 	rm -f dist/aria.js
 	rm -f dist/aria.min.js


### PR DESCRIPTION
Follow-up to #2.

I expect that this does the following:

- Search for chromium on your system and use that if available
- Otherwise use the locally installed one. This will usually fail since chromium is not installed locally by default. The additional target `install-chromium` can be used to fix that.

@matatk what do you think?