### PR TITLE
always ignore noscript elements

### DIFF
--- a/lib/attrs.js
+++ b/lib/attrs.js
@@ -46,6 +46,10 @@ var getAttribute = function(el, key) {
 	} else if (key === 'invalid' && el.checkValidity) {
 		return !el.checkValidity();
 	} else if (key === 'hidden') {
+		// workaround for chromium
+		if (el.matches('noscript')) {
+			return true;
+		}
 		var style = window.getComputedStyle(el);
 		if (style.display === 'none' || style.visibility === 'hidden') {
 			return true;

--- a/test/test-name.js
+++ b/test/test-name.js
@@ -22,4 +22,10 @@ describe('getName / getDescription', function() {
 			}
 		});
 	});
+
+	it('ingores <noscript>', function() {
+		testbed.innerHTML = '<a id="test" href="#">test <noscript>moo</noscript></a>';
+		var element = document.querySelector('#test');
+		expect(aria.getName(element)).toBe('test');
+	});
 });


### PR DESCRIPTION
fixes #7

chromium has default style of `display: inline` instead of `display: none`

@jribbens  can you please verify whether this indeed does fix the issue?