### PR TITLE
detectLoop() can crash on loops

### DIFF
--- a/dist/aria.js
+++ b/dist/aria.js
@@ -35,12 +35,12 @@ var _getParentNode = function(node) {
 };
 
 var detectLoop = function(node) {
-	var tmp = _getParentNode(node);
-	while (tmp) {
-		if (tmp === node) {
+	var seen = [node]
+	while ((node = _getParentNode(node))) {
+		if (seen.includes(node)) {
 			return true;
 		}
-		tmp = _getParentNode(tmp);
+		seen.push(node)
 	}
 };
 

--- a/lib/atree.js
+++ b/lib/atree.js
@@ -14,12 +14,12 @@ var _getParentNode = function(node) {
 };
 
 var detectLoop = function(node) {
-	var tmp = _getParentNode(node);
-	while (tmp) {
-		if (tmp === node) {
+	var seen = [node]
+	while ((node = _getParentNode(node))) {
+		if (seen.includes(node)) {
 			return true;
 		}
-		tmp = _getParentNode(tmp);
+		seen.push(node)
 	}
 };
 

--- a/test/index.html
+++ b/test/index.html
@@ -37,6 +37,7 @@
     <script src="test-role.js"></script>
     <script src="test-hidden.js"></script>
     <script src="test-conflict.js"></script>
+    <script src="test-loop.js"></script>
     <script>mocha.run()</script>
 </body>
 </html>

--- a/test/test-loop.js
+++ b/test/test-loop.js
@@ -1,0 +1,19 @@
+describe('detectLoop()', function() {
+	var testbed;
+
+	beforeEach(function() {
+		testbed = document.createElement('div');
+		// make sure styles are actually computed
+		document.body.appendChild(testbed);
+	});
+
+	afterEach(function() {
+		document.body.removeChild(testbed);
+	});
+
+	it('detects loops', function() {
+		testbed.innerHTML = '<span id="a"><a id="test" href="#" aria-owns="b">test</a><a href="#" aria-owns="a"></a></span><span id="b"><a href="#" aria-owns="a"></a></span>';
+		var element = document.querySelector('#test');
+		expect(aria.getName(element)).toBe('test');
+	});
+});


### PR DESCRIPTION
If you have code such as:
```html
<span id="a">
  <a id="test" href="#" aria-owns="b">test</a>
  <a href="#" aria-owns="a"></a>
</span>
<span id="b">
  <a href="#" aria-owns="a"></a>
</span>
```
and you call `getName()` on `#test` then `detectLoop()` detects the loop by going into an infinite loop and crashing. This patch fixes it so it returns `true` instead.